### PR TITLE
Add custom TFE Agent container to fix CA trust issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ To build and run the Dnsmasq container, follow these steps:
     docker build -t dnsmasq .
     ```
 
+#### TFE Agent Container
+To build and run the TFE Agent container, follow these steps:
+
+1. Copy the `certs/cert.pem` file from the TFE installation directory into the `./tfe-agent` directory:
+    ```
+    cp ./certs/cert.pem ./tfe-agent/certificate.crt
+    ```
+2. Go into the `./tfe-agent` directory.
+3. Build the container locally using the following command:
+    ```
+    docker build -t tfe-agent .
+    ```
+
 ## Usage
 Once all the containers have been built, you should be able to run 
     ```

--- a/compose.yaml
+++ b/compose.yaml
@@ -30,6 +30,7 @@ services:
       TFE_DATABASE_RECONNECT_ENABLED: true
       TFE_RUN_PIPELINE_DOCKER_EXTRA_HOSTS: "tfe.local:10.5.0.2"
       TFE_RUN_PIPELINE_DOCKER_NETWORK: "app_network"
+      TFE_RUN_PIPELINE_IMAGE: "tfe-agent"
     cap_add:
       - IPC_LOCK
     read_only: true

--- a/tfe-agent/Dockerfile
+++ b/tfe-agent/Dockerfile
@@ -1,0 +1,8 @@
+FROM hashicorp/tfc-agent:latest
+
+USER root
+# add custom CA certificate, if needed
+ADD certificate.crt /usr/local/share/ca-certificates/
+RUN update-ca-certificates
+
+USER tfc-agent


### PR DESCRIPTION
This pull request adds a Dockerfile and instructions for building a custom TFE agent and the Compose service changes to use it.

The custom agent adds the certificate used by TFE to the CA certificates file so it is trusted by task workers.